### PR TITLE
Add Android NDK hello world sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore binaries generated from android_hello sample
+android_hello/hello_android*

--- a/android_hello/README.md
+++ b/android_hello/README.md
@@ -1,0 +1,27 @@
+# Android Native Hello
+
+This directory contains a minimal native program for Android that prints
+`Hello Android from NDK!`.
+
+## Build for ARM64 using Android NDK
+
+1. Download and extract the [Android NDK](https://developer.android.com/ndk) for Linux.
+2. Set `NDK_ROOT` to the extracted directory.
+3. Compile using the `aarch64` toolchain:
+
+```bash
+$ $NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang \
+    hello_android.c -o hello_android
+```
+
+The resulting `hello_android` binary runs on Android ARM64 devices or emulators.
+
+## Build for host (optional)
+
+To verify the code on the host system:
+
+```bash
+$ gcc hello_android.c -o hello_android
+$ ./hello_android
+```
+

--- a/android_hello/build_arm64.sh
+++ b/android_hello/build_arm64.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+: "${NDK_ROOT:?Set NDK_ROOT to your Android NDK path}"
+"$NDK_ROOT"/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang \
+    hello_android.c -o hello_android

--- a/android_hello/hello_android.c
+++ b/android_hello/hello_android.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello Android from NDK!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple native `hello_android.c` for Android
- include ARM64 build script using Android NDK
- document build instructions and ignore generated binaries

## Testing
- `gcc android_hello/hello_android.c -o android_hello/hello_android_x86 && ./android_hello/hello_android_x86`
- `cd android_hello && ./build_arm64.sh` *(fails: NDK_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aef0ffa038832893ab36cc38f43e0f