### PR TITLE
Add ARM64 Android environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # trycodex
-try get new
+
+Collection of small experiments.
+
+## Android ARM64 environment
+
+To configure a shell for building Android ARM64 binaries using the NDK:
+
+```bash
+$ export NDK_ROOT=/path/to/android-ndk
+$ source setup_android_arm64_env.sh
+```
+
+You can then build the sample in `android_hello`:
+
+```bash
+$ cd android_hello
+$ ./build_arm64.sh
+```

--- a/android_hello/README.md
+++ b/android_hello/README.md
@@ -7,11 +7,11 @@ This directory contains a minimal native program for Android that prints
 
 1. Download and extract the [Android NDK](https://developer.android.com/ndk) for Linux.
 2. Set `NDK_ROOT` to the extracted directory.
-3. Compile using the `aarch64` toolchain:
+3. Configure the cross-compilation environment and build:
 
 ```bash
-$ $NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang \
-    hello_android.c -o hello_android
+$ source ../setup_android_arm64_env.sh
+$ ./build_arm64.sh
 ```
 
 The resulting `hello_android` binary runs on Android ARM64 devices or emulators.
@@ -24,4 +24,3 @@ To verify the code on the host system:
 $ gcc hello_android.c -o hello_android
 $ ./hello_android
 ```
-

--- a/android_hello/build_arm64.sh
+++ b/android_hello/build_arm64.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -e
-: "${NDK_ROOT:?Set NDK_ROOT to your Android NDK path}"
-"$NDK_ROOT"/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang \
-    hello_android.c -o hello_android
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+if [ -z "${CC:-}" ]; then
+    : "${NDK_ROOT:?Set NDK_ROOT to your Android NDK path}"
+    CC="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+fi
+
+"$CC" "$SCRIPT_DIR/hello_android.c" -o "$SCRIPT_DIR/hello_android"

--- a/setup_android_arm64_env.sh
+++ b/setup_android_arm64_env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Set up environment variables for building Android ARM64 native binaries.
+#
+# Usage: source setup_android_arm64_env.sh
+# Ensure NDK_ROOT is set to your Android NDK directory before running.
+
+set -euo pipefail
+
+if [ -z "${NDK_ROOT:-}" ]; then
+    echo "NDK_ROOT is not set. Please set it to your Android NDK path." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+TOOLCHAIN="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin"
+export PATH="$TOOLCHAIN:$PATH"
+
+export CC=aarch64-linux-android21-clang
+export CXX=aarch64-linux-android21-clang++
+export AR=llvm-ar
+export AS=llvm-as
+export LD=ld.lld
+export NM=llvm-nm
+export RANLIB=llvm-ranlib
+export STRIP=llvm-strip
+
+echo "Android ARM64 build environment configured."


### PR DESCRIPTION
## Summary
- add helper script to configure Android ARM64 cross-compile environment
- update build script and docs to reference environment setup
- make Android build script path-independent

## Testing
- `bash -n setup_android_arm64_env.sh`
- `bash -n android_hello/build_arm64.sh`
- `CC=gcc android_hello/build_arm64.sh && ./android_hello/hello_android`


------
https://chatgpt.com/codex/tasks/task_e_68aef55c03a48328891d7617ea4bd31c